### PR TITLE
Extract non-content docs metadata into a shared config.

### DIFF
--- a/content/configuration.yml
+++ b/content/configuration.yml
@@ -1,0 +1,46 @@
+docs:
+  home:
+    doc_type: ""
+    card_title: Welcome to W4H
+    action_label: Open
+    sort_order: 0
+    hidden: false
+    is_feature_card: false
+    show_in_docs: false
+    card_order: 0
+  quick-start:
+    doc_type: guide
+    card_title: Quick Start
+    action_label: Open
+    sort_order: 1
+    hidden: false
+    is_feature_card: true
+    show_in_docs: true
+    card_order: 1
+  faq:
+    doc_type: faq
+    card_title: FAQ
+    action_label: Open
+    sort_order: 10
+    hidden: false
+    is_feature_card: false
+    show_in_docs: true
+    card_order: 0
+  ansel-todo:
+    doc_type: internal
+    card_title: ""
+    action_label: Open
+    sort_order: 0
+    hidden: false
+    is_feature_card: false
+    show_in_docs: true
+    card_order: 0
+  w4h-app-setup-for-developers:
+    doc_type: internal
+    card_title: ""
+    action_label: Open
+    sort_order: 0
+    hidden: false
+    is_feature_card: false
+    show_in_docs: true
+    card_order: 0

--- a/content/home.md
+++ b/content/home.md
@@ -1,14 +1,6 @@
 ---
-slug: home
 title: Welcome to W4H
-card_title: Welcome to W4H
 description: Welcome to the W4H Toolkit
-action_label: Open
-sort_order: 0
-hidden: false
-show_in_docs: false
-is_feature_card: false
-card_order: 0
 ---
 
 <p class="fs-4">Welcome to the <strong>W4H Toolkit</strong>!</p>

--- a/content/internal/ansel-todo.md
+++ b/content/internal/ansel-todo.md
@@ -1,21 +1,8 @@
 ---
-id: d965b061-ab7c-4894-ba5b-42ce560a25d4
 slug: ansel-todo
 title: Todo
 card_title: ''
 description: ''
-action_label: Open
-doc_type: internal
-sort_order: 0
-hidden: false
-updated_at: '2026-04-13T16:26:03.005261'
-is_feature_card: false
-show_in_docs: true
-toc:
-- id: development
-  level: 2
-  title: Development
-card_order: 0
 ---
 
 # Development

--- a/content/internal/w4h-app-setup-for-developers.md
+++ b/content/internal/w4h-app-setup-for-developers.md
@@ -1,54 +1,7 @@
 ---
-id: 7e1e6339-bb0f-46e2-826e-f9fc6b49dfae
-slug: w4h-app-setup-for-developers
 title: W4H-app Setup for Developers
 card_title: ''
 description: ''
-action_label: Open
-doc_type: internal
-sort_order: 0
-hidden: false
-updated_at: '2026-04-13T16:26:03.005261'
-is_feature_card: false
-show_in_docs: true
-toc:
-- id: w4h-app-setup-for-developers
-  level: 2
-  title: W4H-app Setup for Developers
-- id: system-architecture
-  level: 3
-  title: System architecture
-- id: first-time-setup-workflow
-  level: 3
-  title: First-time setup workflow
-- id: w4h-app-setup
-  level: 3
-  title: w4h-app Setup
-- id: recommended-ide-setup
-  level: 4
-  title: Recommended IDE Setup
-- id: recommended-browser-setup
-  level: 4
-  title: Recommended Browser Setup
-- id: customize-configuration
-  level: 4
-  title: Customize configuration
-- id: project-setup
-  level: 4
-  title: Project Setup
-- id: compile-and-hot-reload-for-development
-  level: 4
-  title: Compile and Hot-Reload for Development
-- id: compile-and-minify-for-production
-  level: 4
-  title: Compile and Minify for Production
-- id: run-end-to-end-tests-with-playwright-https-playwright-dev-
-  level: 4
-  title: Run End-to-End Tests with [Playwright](https://playwright.dev)
-- id: lint-with-eslint-https-eslint-org-
-  level: 4
-  title: Lint with [ESLint](https://eslint.org/)
-card_order: 0
 ---
 
 # W4H-app Setup for Developers


### PR DESCRIPTION
Move UI/layout metadata out of markdown front matter into content/configuration.yml so page content files stay focused on authoring fields and can be reassembled consistently during import.